### PR TITLE
Telemetry dashboard for Otel Kafka - code changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ exporters:
     source: <Source>
     sourcetype: <Sourcetype>
     index: <Splunk index>
+    headers:
+      "__splunk_app_name": "soc4kafka"
 
 service:
   pipelines:
@@ -108,6 +110,8 @@ exporters:
     source: my-kafka
     sourcetype: kafka-otel
     index: kafka_otel
+    headers:
+       "__splunk_app_name": "soc4kafka"
 
 service:
   pipelines:

--- a/docs/extracting_additional_data.md
+++ b/docs/extracting_additional_data.md
@@ -26,6 +26,8 @@ exporters:
    source: my-kafka
    sourcetype: kafka-otel
    index: kafka_otel
+   headers:
+     "__splunk_app_name": "soc4kafka"
    otel_attrs_to_hec_metadata:
      index: kafka.header.index
      host: kafka.header.host
@@ -95,6 +97,8 @@ exporters:
     source: my-kafka
     sourcetype: kafka-otel
     index: kafka_otel
+    headers:
+      "__splunk_app_name": "soc4kafka"
 
 service:
   pipelines:

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -76,6 +76,8 @@ exporters:
    source: my-kafka
    sourcetype: kafka-otel
    index: "logs_index"
+   headers:
+     "__splunk_app_name": "soc4kafka"
 
 service:
  pipelines:
@@ -120,6 +122,8 @@ exporters:
     source: my-kafka
     sourcetype: kafka-otel
     index: "logs_index"
+    headers:
+      "__splunk_app_name": "soc4kafka"
 
 service:
   pipelines:
@@ -160,6 +164,8 @@ exporters:
     source: my-kafka
     sourcetype: kafka-otel
     index: "logs_index"
+    headers:
+      "__splunk_app_name": "soc4kafka"
 
 service:
   telemetry:
@@ -225,6 +231,8 @@ exporters:
  splunk_hec:
    token: "your-splunk-hec-token"
    endpoint: "https://splunk-hec-endpoint:8088/services/collector"
+   headers:
+     "__splunk_app_name": "soc4kafka"
    otel_attrs_to_hec_metadata:
      index: kafka.header.index
      host: kafka.header.host
@@ -298,6 +306,8 @@ exporters:
     source: kafka-otel-three-pat
     sourcetype: kafka-otel
     index: "logs_index"
+    headers:
+      "__splunk_app_name": "soc4kafka"
 
   splunk_hec/2:
     token: "your-splunk-hec-token"
@@ -305,6 +315,8 @@ exporters:
     source: kafka-otel-two-pat
     sourcetype: kafka-otel
     index: "kafka_otel"
+    headers:
+      "__splunk_app_name": "soc4kafka"
 
 service:
   pipelines:
@@ -372,6 +384,8 @@ exporters:
     source: otel
     sourcetype: otel
     index: test
+    headers:
+      "__splunk_app_name": "soc4kafka"
     export_raw: true
 
 service:

--- a/docs/multiple_topics.md
+++ b/docs/multiple_topics.md
@@ -27,12 +27,16 @@ exporters:
    source: my-kafka
    sourcetype: kafka-otel
    index: kafka_otel
+   headers:
+     "__splunk_app_name": "soc4kafka"
  splunk_hec/2:
    token: "your-splunk-hec-token"
    endpoint: "https://splunk-hec-endpoint:8088/services/collector"
    source: my-kafka
    sourcetype: kafka-otel
    index: kafka_otel_another_index
+   headers:
+     "__splunk_app_name": "soc4kafka"
 
 service:
  pipelines:

--- a/docs/regex_topics.md
+++ b/docs/regex_topics.md
@@ -42,6 +42,8 @@ exporters:
    source: my-kafka
    sourcetype: kafka-otel
    index: kafka_otel
+   headers:
+     "__splunk_app_name": "soc4kafka"
 
 service:
  extensions: [kafkatopics_observer]

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -31,6 +31,8 @@ exporters:
    source: my-kafka
    sourcetype: kafka-otel
    index: kafka_otel
+   headers:
+     "__splunk_app_name": "soc4kafka"
 
 service:
  pipelines:

--- a/docs/splunk-dashboard.md
+++ b/docs/splunk-dashboard.md
@@ -148,6 +148,8 @@ exporters:
     source: <source>
     sourcetype: <sourcetype>
     index: <metrics-index>
+    headers:
+      "__splunk_app_name": "soc4kafka"
 ```
 
 Make sure you've created a metric type index:

--- a/quickstart/templates/basic_conf_tmpl.yaml.j2
+++ b/quickstart/templates/basic_conf_tmpl.yaml.j2
@@ -20,6 +20,8 @@ exporters:
     index: {{ splunk_index }}
     tls:
       insecure_skip_verify: {{ insecure_skip_verify | default(false) | lower }}  # Set to true to skip TLS verification (not recommended for production)
+    headers:
+      "__splunk_app_name": "soc4kafka"
 
 service:
   pipelines:


### PR DESCRIPTION
Pull request updates documentation and configuration templates to include a new `headers` field in all Splunk HEC exporter examples. The main change is the addition of the `__splunk_app_name` header set to `"soc4kafka"`, which helps identify the source application for exported data. 

The __splunk_app_name field can be further used in telemetry dashboards

