### PR TITLE
helm: add tls

### DIFF
--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/README.md
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/README.md
@@ -41,6 +41,7 @@ helm upgrade --install soc4kafka splunk-opentelemetry-collector-for-kafka/splunk
 
 - [Installation Guide](docs/installation.md) - How to install and upgrade the chart
 - [Configuration](docs/configuration.md) - Detailed configuration options
+- [TLS Configuration](docs/tls.md) - TLS for Kafka brokers and Splunk HEC (e.g. `ca_pem`, `insecure_skip_verify`)
 - [Examples](docs/examples.md) - Example configurations for common scenarios
 - [Secret Management](docs/secrets.md) - Managing secrets for Splunk HEC tokens and Kafka authentication
 - [Troubleshooting](docs/troubleshooting.md) - Common issues and solutions

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/README.md
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/README.md
@@ -41,7 +41,7 @@ helm upgrade --install soc4kafka splunk-opentelemetry-collector-for-kafka/splunk
 
 - [Installation Guide](docs/installation.md) - How to install and upgrade the chart
 - [Configuration](docs/configuration.md) - Detailed configuration options
-- [TLS Configuration](docs/tls.md) - TLS for Kafka brokers and Splunk HEC (e.g. `ca_pem`, `insecure_skip_verify`)
+- [TLS Configuration](docs/tls.md) - TLS for Kafka receivers and Splunk HEC exporters (same options: `ca_pem`, `ca_file`, `insecure_skip_verify`)
 - [Examples](docs/examples.md) - Example configurations for common scenarios
 - [Secret Management](docs/secrets.md) - Managing secrets for Splunk HEC tokens and Kafka authentication
 - [Troubleshooting](docs/troubleshooting.md) - Common issues and solutions

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/README.md
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/README.md
@@ -41,7 +41,7 @@ helm upgrade --install soc4kafka splunk-opentelemetry-collector-for-kafka/splunk
 
 - [Installation Guide](docs/installation.md) - How to install and upgrade the chart
 - [Configuration](docs/configuration.md) - Detailed configuration options
-- [TLS Configuration](docs/tls.md) - TLS for Kafka receivers and Splunk HEC exporters (same options: `ca_pem`, `ca_file`, `insecure_skip_verify`)
+- [TLS Configuration](docs/tls.md) - TLS for Kafka receivers and Splunk HEC exporters
 - [Examples](docs/examples.md) - Example configurations for common scenarios
 - [Secret Management](docs/secrets.md) - Managing secrets for Splunk HEC tokens and Kafka authentication
 - [Troubleshooting](docs/troubleshooting.md) - Common issues and solutions

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/configuration.md
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/configuration.md
@@ -46,7 +46,7 @@ splunkExporters:
 
 **Note:** Instead of providing `token` directly, you can reference an existing Kubernetes secret using the `secret` field. See [Secret Management](secrets.md) for details.
 
-**TLS:** For HTTPS HEC endpoints, TLS verification can be controlled via the `tls.insecure_skip_verify` option. See [TLS Configuration](tls.md) for details.
+**TLS:** Use `https://` in the endpoint for TLS. The same `tls` options as for Kafka apply (`insecure_skip_verify`, `ca_pem`, `ca_file`, etc.). See [TLS Configuration](tls.md).
 
 ### Pipelines
 
@@ -72,7 +72,7 @@ pipelines:
 
 See [values.yaml](../values.yaml) for all available configuration options. Key areas:
 
-- **TLS** ([tls.md](tls.md)): Configure TLS for Kafka receivers and Splunk HEC exporters (e.g. `ca_pem`, `insecure_skip_verify`)
+- **TLS** ([tls.md](tls.md)): Configure TLS for Kafka receivers and Splunk HEC exporters (same options: `ca_pem`, `ca_file`, `insecure_skip_verify`)
 - **Component Defaults** (`defaults`): Override default OpenTelemetry component settings
 - **Config Override** (`configOverride`): Provide complete OpenTelemetry config override
 - **Resources** (`resources`): Set CPU and memory limits/requests

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/configuration.md
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/configuration.md
@@ -24,6 +24,8 @@ kafkaReceivers:
 
 **Note:** Kafka authentication passwords (plain_text, SASL, or Kerberos) can reference existing Kubernetes secrets using the `secret` field. See [Secret Management](secrets.md) for details.
 
+**TLS:** For TLS-enabled Kafka brokers (e.g. port 9093), add a `tls` block with `insecure_skip_verify` and optionally `ca_pem` (PEM-encoded CA certificate). See [TLS Configuration](tls.md) for full details and examples.
+
 ### Splunk HEC Exporters
 
 Define one or more Splunk HEC exporters. All standard Splunk HEC exporter configuration options are supported. See the [SOC4Kafka design documentation](../../../docs/otel_design.md) for details.
@@ -43,6 +45,8 @@ splunkExporters:
 **Chart-specific:** The `name` field is required and used to reference the exporter in pipelines.
 
 **Note:** Instead of providing `token` directly, you can reference an existing Kubernetes secret using the `secret` field. See [Secret Management](secrets.md) for details.
+
+**TLS:** For HTTPS HEC endpoints, TLS verification can be controlled via the `tls.insecure_skip_verify` option. See [TLS Configuration](tls.md) for details.
 
 ### Pipelines
 
@@ -68,6 +72,7 @@ pipelines:
 
 See [values.yaml](../values.yaml) for all available configuration options. Key areas:
 
+- **TLS** ([tls.md](tls.md)): Configure TLS for Kafka receivers and Splunk HEC exporters (e.g. `ca_pem`, `insecure_skip_verify`)
 - **Component Defaults** (`defaults`): Override default OpenTelemetry component settings
 - **Config Override** (`configOverride`): Provide complete OpenTelemetry config override
 - **Resources** (`resources`): Set CPU and memory limits/requests

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/configuration.md
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/configuration.md
@@ -24,7 +24,7 @@ kafkaReceivers:
 
 **Note:** Kafka authentication passwords (plain_text, SASL, or Kerberos) can reference existing Kubernetes secrets using the `secret` field. See [Secret Management](secrets.md) for details.
 
-**TLS:** For TLS-enabled Kafka brokers (e.g. port 9093), add a `tls` block with `insecure_skip_verify` and optionally `ca_pem` (PEM-encoded CA certificate). See [TLS Configuration](tls.md) for full details and examples.
+**TLS:** For TLS-enabled Kafka brokers (e.g. port 9093), add a `tls` block. See [TLS Configuration](tls.md) for full details and examples.
 
 ### Splunk HEC Exporters
 
@@ -46,7 +46,7 @@ splunkExporters:
 
 **Note:** Instead of providing `token` directly, you can reference an existing Kubernetes secret using the `secret` field. See [Secret Management](secrets.md) for details.
 
-**TLS:** Use `https://` in the endpoint for TLS. The same `tls` options as for Kafka apply (`insecure_skip_verify`, `ca_pem`, `ca_file`, etc.). See [TLS Configuration](tls.md).
+**TLS:** Use `https://` in the endpoint for TLS. The same `tls` options as for Kafka apply. See [TLS Configuration](tls.md).
 
 ### Pipelines
 
@@ -72,7 +72,7 @@ pipelines:
 
 See [values.yaml](../values.yaml) for all available configuration options. Key areas:
 
-- **TLS** ([tls.md](tls.md)): Configure TLS for Kafka receivers and Splunk HEC exporters (same options: `ca_pem`, `ca_file`, `insecure_skip_verify`)
+- **TLS** ([tls.md](tls.md)): Configure TLS for Kafka receivers and Splunk HEC exporters.
 - **Component Defaults** (`defaults`): Override default OpenTelemetry component settings
 - **Config Override** (`configOverride`): Provide complete OpenTelemetry config override
 - **Resources** (`resources`): Set CPU and memory limits/requests

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/examples.md
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/examples.md
@@ -89,6 +89,46 @@ pipelines:
       - error-index
 ```
 
+## Kafka with TLS (e.g. port 9093)
+
+When connecting to TLS-enabled Kafka brokers, add a `tls` block. Use `ca_pem` for a custom CA and set `insecure_skip_verify` only for development:
+
+```yaml
+kafkaReceivers:
+  - name: third
+    brokers:
+      - "secure-kafka:9093"
+    logs:
+      topics:
+        - "perf3"
+    group_id: "soc4kafka-main3"
+    tls:
+      insecure_skip_verify: true   # Use false in production; provide ca_pem for broker CA
+      ca_pem: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        G8jotQpS1QbFzo8o3fRN/xQ=
+        -----END CERTIFICATE-----
+
+splunkExporters:
+  - name: primary
+    endpoint: "https://splunk:8088/services/collector"
+    secret: "splunk-hec-secret"
+    source: "kafka"
+    sourcetype: "otel:logs"
+    index: "main"
+
+pipelines:
+  - name: logs
+    type: logs
+    receivers:
+      - third
+    exporters:
+      - primary
+```
+
+See [TLS Configuration](tls.md) for all options and security recommendations.
+
 ## Authenticated Kafka with Secret Management
 
 ```yaml

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/examples.md
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/examples.md
@@ -103,7 +103,9 @@ kafkaReceivers:
         - "perf3"
     group_id: "soc4kafka-main3"
     tls:
-      insecure_skip_verify: true   # Use false in production; provide ca_pem for broker CA
+      insecure_skip_verify: true   # Use false in production;
+      
+      # provide ca_pem for broker CA
       ca_pem: |
         -----BEGIN CERTIFICATE-----
         ...

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/tls.md
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/tls.md
@@ -14,7 +14,7 @@ Use a custom CA certificate to verify the Kafka broker when the broker uses a pr
 kafkaReceivers:
   - name: third
     brokers:
-      - "ec2-52-36-203-237.us-west-2.compute.amazonaws.com:9093"
+      - "kafka-broker-1:9093"
     logs:
       topics:
         - "perf3"
@@ -34,6 +34,13 @@ kafkaReceivers:
 |--------|------|-------------|
 | `insecure_skip_verify` | boolean | When `true`, skips verification of the broker's TLS certificate. Use only for development or testing. Default: `false`. |
 | `ca_pem` | string | PEM-encoded CA certificate(s) used to verify the broker's certificate. Use for brokers signed by a private or corporate CA. |
+| `ca_file` | string | Path to the CA cert. For a client this verifies the server certificate. Use with a mounted secret when you prefer file path over inline `ca_pem`. |
+| `cert_file` | string | Path to the TLS cert to use for TLS required connections. Should only be used if `insecure` is set to false. |
+| `cert_pem` | string | Alternative to `cert_file`. Provide the certificate contents as a string instead of a filepath. |
+| `key_file` | string | Path to the TLS key to use for TLS required connections. Should only be used if `insecure` is set to false. |
+| `key_pem` | string | Alternative to `key_file`. Provide the key contents as a string instead of a filepath. |
+
+Additional TLS settings (e.g. `insecure`, `curve_preferences`, `include_system_ca_certs_pool`, `min_version`, `max_version`, `cipher_suites`, `reload_interval`; for exporters also `server_name_override`) are supported by the collector and passed through to the config. For the full reference, see the [OpenTelemetry Collector TLS Configuration Settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md).
 
 ### Security recommendations
 
@@ -64,7 +71,7 @@ You can mount a Secret containing the CA certificate using `extraVolumes` and `e
 
    kafkaReceivers:
      - name: main
-       brokers: ["kafka:9093"]
+       brokers: ["kafka-broker-1:9093"]
        tls:
          insecure_skip_verify: false
          ca_file: /etc/ssl/kafka/ca.pem

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/tls.md
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/tls.md
@@ -40,7 +40,7 @@ kafkaReceivers:
 | `key_file` | string | Path to the TLS key to use for TLS required connections. Should only be used if `insecure` is set to false. |
 | `key_pem` | string | Alternative to `key_file`. Provide the key contents as a string instead of a filepath. |
 
-Additional TLS settings (e.g. `insecure`, `curve_preferences`, `include_system_ca_certs_pool`, `min_version`, `max_version`, `cipher_suites`, `reload_interval`; for exporters also `server_name_override`) are supported by the collector and passed through to the config. For the full reference, see the [OpenTelemetry Collector TLS Configuration Settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md).
+Additional TLS settings are supported by the collector and passed through to the config. For the full reference, see the [OpenTelemetry Collector TLS Configuration Settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md).
 
 ### Security recommendations
 
@@ -80,16 +80,9 @@ You can mount a Secret containing the CA certificate using `extraVolumes` and `e
 
    Note: Secret keys are mounted as files; if your secret key is `ca.pem`, the path is `/<mountPath>/ca.pem`.
 
-### Using a CA from a secret (inline ca_pem)
-
-To avoid mounting a file, you can inject the CA PEM into the `ca_pem` field at deploy time:
-
-- **External Secrets / Sealed Secrets / Vault:** Store the CA in a secret and use your tooling to inject the secret value into the `ca_pem` field in your Helm values before or during `helm upgrade`.
-- **CI/CD:** Have your pipeline read the CA from a secret store and write it into the values (or a generated values file) used for the release.
-
 ## Splunk HEC Exporter TLS
 
-The Splunk HEC exporter uses TLS when the `endpoint` URL uses `https://`. The **same `tls` options** as for Kafka receivers apply (see the [TLS options](#tls-options) table above): `insecure_skip_verify`, `ca_pem`, `ca_file`, and any other options supported by the collector are passed through.
+The Splunk HEC exporter uses TLS when the `endpoint` URL uses `https://`. The **same `tls` options** as for Kafka receivers apply (see the [TLS options](#tls-options) table above).
 
 Example with custom CA or relaxed verification:
 
@@ -99,7 +92,6 @@ splunkExporters:
     endpoint: "https://splunk-hec:8088/services/collector"
     token: "your-token"
     tls:
-      insecure_skip_verify: false   # Set true only for self-signed / dev
       # ca_pem: | ...               # Optional: PEM for private CA
       # ca_file: /etc/ssl/hec/ca.pem   # Optional: path if mounted via extraVolumes/extraVolumeMounts
 ```

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/tls.md
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/tls.md
@@ -60,7 +60,7 @@ splunkExporters:
 
 ## Using a CA from a Kubernetes secret (file path)
 
-You can mount a Secret containing the CA certificate using `extraVolumes` and `extraVolumeMounts` in your values, then reference it with `tls.ca_file` in the Kafka receiver or Splunk HEC exporter. The same approach works for **`cert_file`** and **`key_file`** (client certificate and key for mTLS): put the cert and key in the secret, mount the secret, and set `tls.cert_file` and `tls.key_file` to the paths inside the container.
+You can mount a Secret containing the CA certificate using `extraVolumes` and `extraVolumeMounts` in your values, then reference it with `tls.ca_file` in the Kafka receiver or Splunk HEC exporter. The same approach works for **`cert_file`** and **`key_file`**.
 
 1. Create a Secret with the CA certificate (and optionally client cert/key; use a name that matches your use case, e.g. `kafka-ca` or `hec-ca`):
 
@@ -114,12 +114,12 @@ You can mount a Secret containing the CA certificate using `extraVolumes` and `e
          ca_file: /etc/ssl/hec/ca.pem
    ```
 
-   Secret keys are mounted as files; if your secret key is `ca.pem`, the path is `/<mountPath>/ca.pem`. The same volume can hold multiple files (e.g. `ca.pem`, `cert.pem`, `key.pem`); reference each in `tls` as `ca_file`, `cert_file`, and `key_file`. You can define both Kafka and HEC volumes/mounts in the same values file if you need custom CAs (or client certs) for each.
+   Secret keys are mounted as files; if your secret key is `ca.pem`, the path is `/<mountPath>/ca.pem`. The same volume can hold multiple files (e.g. `ca.pem`, `cert.pem`, `key.pem`); reference each in `tls` as `ca_file`, `cert_file`, and `key_file`.
 
 
 ## Security recommendations
 
-- **Production:** Set `insecure_skip_verify: false` and provide the broker's CA via `ca_pem`. This ensures the collector only connects to brokers that present a certificate signed by your CA.
+- **Production:** Set `insecure_skip_verify: false` so the server certificate is verified. When the broker uses a private or corporate CA, provide that CA via `ca_pem` or `ca_file` so the collector only connects to brokers whose certificate is signed by your CA.
 - **Development/testing:** You may set `insecure_skip_verify: true` for self-signed or internal brokers. Do not use this in production, as it is vulnerable to man-in-the-middle attacks.
 
 

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/tls.md
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/tls.md
@@ -42,22 +42,37 @@ kafkaReceivers:
 
 Additional TLS settings are supported by the collector and passed through to the config. For the full reference, see the [OpenTelemetry Collector TLS Configuration Settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md).
 
-### Security recommendations
+## Splunk HEC Exporter TLS
 
-- **Production:** Set `insecure_skip_verify: false` and provide the broker's CA via `ca_pem`. This ensures the collector only connects to brokers that present a certificate signed by your CA.
-- **Development/testing:** You may set `insecure_skip_verify: true` for self-signed or internal brokers. Do not use this in production, as it is vulnerable to man-in-the-middle attacks.
+The Splunk HEC exporter uses TLS when the `endpoint` URL uses `https://`. The **same `tls` options** as for Kafka receivers apply (see the [TLS options](#tls-options) table above).
 
-### Using a CA from a Kubernetes secret (file path)
+Example with custom CA or relaxed verification:
 
-You can mount a Secret containing the CA certificate using `extraVolumes` and `extraVolumeMounts` in your values, then reference it with `ca_file` in the Kafka receiver (if the receiver supports it):
+```yaml
+splunkExporters:
+  - name: primary
+    endpoint: "https://splunk-hec:8088/services/collector"
+    token: "your-token"
+    tls:
+      # ca_pem: | ...               # Optional: PEM for private CA
+      # ca_file: /etc/ssl/hec/ca.pem   # Optional: path if mounted via extraVolumes/extraVolumeMounts
+```
 
-1. Create a Secret with the CA certificate:
+## Using a CA from a Kubernetes secret (file path)
+
+You can mount a Secret containing the CA certificate using `extraVolumes` and `extraVolumeMounts` in your values, then reference it with `tls.ca_file` in the Kafka receiver or Splunk HEC exporter. The same approach works for **`cert_file`** and **`key_file`** (client certificate and key for mTLS): put the cert and key in the secret, mount the secret, and set `tls.cert_file` and `tls.key_file` to the paths inside the container.
+
+1. Create a Secret with the CA certificate (and optionally client cert/key; use a name that matches your use case, e.g. `kafka-ca` or `hec-ca`):
 
    ```bash
    kubectl create secret generic kafka-ca --from-file=ca.pem=/path/to/ca.pem
+   # or for HEC:
+   kubectl create secret generic hec-ca --from-file=ca.pem=/path/to/hec-ca.pem
    ```
 
-2. In your Helm values, add the volume and mount, and set `tls.ca_file` to the path inside the container:
+2. In your Helm values, add the volume and mount, and set `tls.ca_file` to the path inside the container.
+
+   **Kafka receiver example:**
 
    ```yaml
    extraVolumes:
@@ -78,23 +93,35 @@ You can mount a Secret containing the CA certificate using `extraVolumes` and `e
        # ... logs, group_id, etc.
    ```
 
-   Note: Secret keys are mounted as files; if your secret key is `ca.pem`, the path is `/<mountPath>/ca.pem`.
+   **Splunk HEC exporter example:**
 
-## Splunk HEC Exporter TLS
+   ```yaml
+   extraVolumes:
+     - name: hec-ca
+       secret:
+         secretName: hec-ca
+   extraVolumeMounts:
+     - name: hec-ca
+       mountPath: /etc/ssl/hec
+       readOnly: true
 
-The Splunk HEC exporter uses TLS when the `endpoint` URL uses `https://`. The **same `tls` options** as for Kafka receivers apply (see the [TLS options](#tls-options) table above).
+   splunkExporters:
+     - name: primary
+       endpoint: "https://splunk-hec:8088/services/collector"
+       token: "your-token"
+       tls:
+         insecure_skip_verify: false
+         ca_file: /etc/ssl/hec/ca.pem
+   ```
 
-Example with custom CA or relaxed verification:
+   Secret keys are mounted as files; if your secret key is `ca.pem`, the path is `/<mountPath>/ca.pem`. The same volume can hold multiple files (e.g. `ca.pem`, `cert.pem`, `key.pem`); reference each in `tls` as `ca_file`, `cert_file`, and `key_file`. You can define both Kafka and HEC volumes/mounts in the same values file if you need custom CAs (or client certs) for each.
 
-```yaml
-splunkExporters:
-  - name: primary
-    endpoint: "https://splunk-hec:8088/services/collector"
-    token: "your-token"
-    tls:
-      # ca_pem: | ...               # Optional: PEM for private CA
-      # ca_file: /etc/ssl/hec/ca.pem   # Optional: path if mounted via extraVolumes/extraVolumeMounts
-```
+
+## Security recommendations
+
+- **Production:** Set `insecure_skip_verify: false` and provide the broker's CA via `ca_pem`. This ensures the collector only connects to brokers that present a certificate signed by your CA.
+- **Development/testing:** You may set `insecure_skip_verify: true` for self-signed or internal brokers. Do not use this in production, as it is vulnerable to man-in-the-middle attacks.
+
 
 ## See also
 

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/tls.md
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/tls.md
@@ -1,0 +1,102 @@
+# TLS Configuration
+
+This document describes how to configure TLS for the Splunk OpenTelemetry Collector for Kafka, including connecting to TLS-enabled Kafka brokers and (optionally) securing the connection to Splunk HEC.
+
+## Kafka Receiver TLS
+
+When your Kafka brokers use TLS (for example, port 9093 with SSL), configure the `tls` block under each Kafka receiver.
+
+### Example: TLS with custom CA
+
+Use a custom CA certificate to verify the Kafka broker when the broker uses a private or corporate CA:
+
+```yaml
+kafkaReceivers:
+  - name: third
+    brokers:
+      - "ec2-52-36-203-237.us-west-2.compute.amazonaws.com:9093"
+    logs:
+      topics:
+        - "perf3"
+    group_id: "soc4kafka-main3"
+    tls:
+      insecure_skip_verify: false
+      ca_pem: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        G8jotQpS1QbFzo8o3fRN/xQ=
+        -----END CERTIFICATE-----
+```
+
+### TLS options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `insecure_skip_verify` | boolean | When `true`, skips verification of the broker's TLS certificate. Use only for development or testing. Default: `false`. |
+| `ca_pem` | string | PEM-encoded CA certificate(s) used to verify the broker's certificate. Use for brokers signed by a private or corporate CA. |
+
+### Security recommendations
+
+- **Production:** Set `insecure_skip_verify: false` and provide the broker's CA via `ca_pem`. This ensures the collector only connects to brokers that present a certificate signed by your CA.
+- **Development/testing:** You may set `insecure_skip_verify: true` for self-signed or internal brokers. Do not use this in production, as it is vulnerable to man-in-the-middle attacks.
+
+### Using a CA from a Kubernetes secret (file path)
+
+You can mount a Secret containing the CA certificate using `extraVolumes` and `extraVolumeMounts` in your values, then reference it with `ca_file` in the Kafka receiver (if the receiver supports it):
+
+1. Create a Secret with the CA certificate:
+
+   ```bash
+   kubectl create secret generic kafka-ca --from-file=ca.pem=/path/to/ca.pem
+   ```
+
+2. In your Helm values, add the volume and mount, and set `tls.ca_file` to the path inside the container:
+
+   ```yaml
+   extraVolumes:
+     - name: kafka-ca
+       secret:
+         secretName: kafka-ca
+   extraVolumeMounts:
+     - name: kafka-ca
+       mountPath: /etc/ssl/kafka
+       readOnly: true
+
+   kafkaReceivers:
+     - name: main
+       brokers: ["kafka:9093"]
+       tls:
+         insecure_skip_verify: false
+         ca_file: /etc/ssl/kafka/ca.pem
+       # ... logs, group_id, etc.
+   ```
+
+   Note: Secret keys are mounted as files; if your secret key is `ca.pem`, the path is `/<mountPath>/ca.pem`.
+
+### Using a CA from a secret (inline ca_pem)
+
+To avoid mounting a file, you can inject the CA PEM into the `ca_pem` field at deploy time:
+
+- **External Secrets / Sealed Secrets / Vault:** Store the CA in a secret and use your tooling to inject the secret value into the `ca_pem` field in your Helm values before or during `helm upgrade`.
+- **CI/CD:** Have your pipeline read the CA from a secret store and write it into the values (or a generated values file) used for the release.
+
+## Splunk HEC exporter TLS
+
+The Splunk HEC exporter uses TLS when the `endpoint` URL scheme is `https://`. You can control certificate verification for the HEC endpoint:
+
+```yaml
+splunkExporters:
+  - name: primary
+    endpoint: "https://splunk-hec:8088/services/collector"
+    token: "your-token"
+    tls:
+      insecure_skip_verify: false
+```
+
+- **`insecure_skip_verify: false`** (default): The collector verifies the HEC server's certificate using the system trust store. Use this in production.
+- **`insecure_skip_verify: true`**: Skips certificate verification. Use only for development or when the HEC server uses a self-signed certificate and you cannot add its CA to the trust store.
+
+## See also
+
+- [Configuration](configuration.md) – Core configuration options
+- [Secret Management](secrets.md) – Managing tokens and passwords securely

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/tls.md
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/tls.md
@@ -90,7 +90,6 @@ You can mount a Secret containing the CA certificate using `extraVolumes` and `e
        tls:
          insecure_skip_verify: false
          ca_file: /etc/ssl/kafka/ca.pem
-       # ... logs, group_id, etc.
    ```
 
    **Splunk HEC exporter example:**
@@ -119,8 +118,7 @@ You can mount a Secret containing the CA certificate using `extraVolumes` and `e
 
 ## Security recommendations
 
-- **Production:** Set `insecure_skip_verify: false` so the server certificate is verified. When the broker uses a private or corporate CA, provide that CA via `ca_pem` or `ca_file` so the collector only connects to brokers whose certificate is signed by your CA.
-- **Development/testing:** You may set `insecure_skip_verify: true` for self-signed or internal brokers. Do not use this in production, as it is vulnerable to man-in-the-middle attacks.
+You may set `insecure_skip_verify: true` for self-signed or internal brokers. Do not use this in production, as it is vulnerable to man-in-the-middle attacks.
 
 
 ## See also

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/tls.md
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/docs/tls.md
@@ -1,6 +1,6 @@
 # TLS Configuration
 
-This document describes how to configure TLS for the Splunk OpenTelemetry Collector for Kafka, including connecting to TLS-enabled Kafka brokers and (optionally) securing the connection to Splunk HEC.
+This document describes how to configure TLS for **Kafka receivers** (e.g. port 9093) and **Splunk HEC exporters**. Both use the same `tls` options; the options table and patterns below apply to each.
 
 ## Kafka Receiver TLS
 
@@ -87,9 +87,11 @@ To avoid mounting a file, you can inject the CA PEM into the `ca_pem` field at d
 - **External Secrets / Sealed Secrets / Vault:** Store the CA in a secret and use your tooling to inject the secret value into the `ca_pem` field in your Helm values before or during `helm upgrade`.
 - **CI/CD:** Have your pipeline read the CA from a secret store and write it into the values (or a generated values file) used for the release.
 
-## Splunk HEC exporter TLS
+## Splunk HEC Exporter TLS
 
-The Splunk HEC exporter uses TLS when the `endpoint` URL scheme is `https://`. You can control certificate verification for the HEC endpoint:
+The Splunk HEC exporter uses TLS when the `endpoint` URL uses `https://`. The **same `tls` options** as for Kafka receivers apply (see the [TLS options](#tls-options) table above): `insecure_skip_verify`, `ca_pem`, `ca_file`, and any other options supported by the collector are passed through.
+
+Example with custom CA or relaxed verification:
 
 ```yaml
 splunkExporters:
@@ -97,11 +99,10 @@ splunkExporters:
     endpoint: "https://splunk-hec:8088/services/collector"
     token: "your-token"
     tls:
-      insecure_skip_verify: false
+      insecure_skip_verify: false   # Set true only for self-signed / dev
+      # ca_pem: | ...               # Optional: PEM for private CA
+      # ca_file: /etc/ssl/hec/ca.pem   # Optional: path if mounted via extraVolumes/extraVolumeMounts
 ```
-
-- **`insecure_skip_verify: false`** (default): The collector verifies the HEC server's certificate using the system trust store. Use this in production.
-- **`insecure_skip_verify: true`**: Skips certificate verification. Use only for development or when the HEC server uses a self-signed certificate and you cannot add its CA to the trust store.
 
 ## See also
 

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/templates/deployment.yaml
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/templates/deployment.yaml
@@ -154,6 +154,9 @@ spec:
             - name: collector-logs
               mountPath: /var/log/otelcol
             {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: config
           configMap:
@@ -169,6 +172,9 @@ spec:
             {{- if .Values.collectorLogs.sizeLimit }}
             sizeLimit: {{ .Values.collectorLogs.sizeLimit }}
             {{- end }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/values.schema.json
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/values.schema.json
@@ -27,6 +27,10 @@
           "group_id": {
             "type": "string",
             "description": "Kafka consumer group ID"
+          },
+          "tls": {
+            "type": "object",
+            "description": "TLS configuration for Kafka broker connection (e.g. when using port 9093). Passed through to the receiver; common options include insecure_skip_verify, ca_pem, ca_file. See docs/tls.md."
           }
         }
       }

--- a/helm-chart/splunk-opentelemetry-collector-for-kafka/values.yaml
+++ b/helm-chart/splunk-opentelemetry-collector-for-kafka/values.yaml
@@ -37,6 +37,13 @@ replicaCount: 1
 #       # Or for Kerberos:
 #       # kerberos:
 #       #   secret: "kafka-kerberos-secret"
+#     # TLS for Kafka brokers (e.g. port 9093). See docs/tls.md.
+#     tls:
+#       insecure_skip_verify: false
+#       ca_pem: |
+#         -----BEGIN CERTIFICATE-----
+#         ...
+#         -----END CERTIFICATE-----
 kafkaReceivers: []
 
 # Define multiple Splunk HEC exporters easily
@@ -194,6 +201,20 @@ extraEnv: [ ]
 # extraEnv:
 #   - name: OTEL_LOG_LEVEL
 #     value: "debug"
+
+# Extra volumes and volume mounts for the collector container (e.g. mount Kafka CA from a secret for tls.ca_file).
+# extraVolumes are defined at the pod level; extraVolumeMounts are mounted into the collector container.
+extraVolumes: [ ]
+extraVolumeMounts: [ ]
+# Example: mount a secret containing Kafka CA certificate for TLS (use with tls.ca_file in kafkaReceivers):
+# extraVolumes:
+#   - name: kafka-ca
+#     secret:
+#       secretName: kafka-ca
+# extraVolumeMounts:
+#   - name: kafka-ca
+#     mountPath: /etc/ssl/kafka
+#     readOnly: true
 
 # Service configuration (optional - probes work without it, but useful for monitoring/debugging)
 service:


### PR DESCRIPTION
This PR includes:

- TLS documentation (`docs/tls.md`): TLS for Kafka receivers and Splunk HEC exporters (same options). Covers `ca_pem` / `ca_file`, optional `cert_file` / `key_file`, examples with inline PEM and with mounted secrets.

- `extraVolumes` / `extraVolumeMounts`: New values and deployment wiring so users can mount Secrets (e.g. Kafka or HEC CA, client cert/key) and reference them via `tls.ca_file`, `tls.cert_file`, `tls.key_file`.