### PR TITLE
fix: special char in tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ processors:
 
 exporters:
   splunk_hec:
-    token: <Splunk HEC Token>
+    token: "<Splunk HEC Token>"
     endpoint: <Splunk HEC Endpoint>
     source: <Source>
     sourcetype: <Sourcetype>

--- a/docs/oci_installation.md
+++ b/docs/oci_installation.md
@@ -27,9 +27,11 @@ Collect the following before touching the VM. Everything in this document is a
 | OCI auth token (SASL password) | Profile → User Settings → **Auth Tokens** → Generate Token — copy immediately, shown once | `<OCI_AUTH_TOKEN>` |
 | Stream / topic name | Streaming → **Streams** | `<TOPIC>` |
 
-> **Auth token constraint:** the token must **not begin with** `#`, `&`, `*`, `!`, `>`, `|`, `@`,
-> or `` ` ``. These characters have special meaning in YAML and will silently break the collector
-> configuration. If your generated token starts with one of them, delete it and generate a new one.
+> **Handling special characters:** the OCI auth token may contain characters like `&`, `|`, `>`,
+> `` ` ``, or `!` — no need to regenerate the token if it does. Just make sure to keep the single
+> quotes shown around `KAFKA_SASL_PASS` and `--from-literal=...` below when you set it: without
+> them, the **shell** interprets those characters itself and can silently truncate or empty out
+> the value before it ever reaches the collector.
 
 ### From Splunk
 

--- a/quickstart/templates/basic_conf_tmpl.yaml.j2
+++ b/quickstart/templates/basic_conf_tmpl.yaml.j2
@@ -14,11 +14,11 @@ processors:
 
 exporters:
   splunk_hec:
-    token: {{ splunk_hec_token }}
-    endpoint: {{ splunk_hec_endpoint }}
-    source: {{ source }}
-    sourcetype: {{ sourcetype }}
-    index: {{ splunk_index }}
+    token: "{{ splunk_hec_token }}"
+    endpoint: "{{ splunk_hec_endpoint }}"
+    source: "{{ source }}"
+    sourcetype: "{{ sourcetype }}"
+    index: "{{ splunk_index }}"
     splunk_app_name: "soc4kafka"
     tls:
       insecure_skip_verify: {{ insecure_skip_verify | default(false) | lower }}  # Set to true to skip TLS verification (not recommended for production)

--- a/tests/functional_tests/testdata/configs/basic_test.yaml.tmpl
+++ b/tests/functional_tests/testdata/configs/basic_test.yaml.tmpl
@@ -9,7 +9,7 @@ receivers:
 
 exporters:
   splunk_hec:
-    token: {{ .SplunkHECToken }}
+    token: "{{ .SplunkHECToken }}"
     endpoint: {{ .SplunkHECEndpoint }}
     tls:
       insecure_skip_verify: true

--- a/tests/functional_tests/testdata/configs/custom_headers_test.yaml.tmpl
+++ b/tests/functional_tests/testdata/configs/custom_headers_test.yaml.tmpl
@@ -12,7 +12,7 @@ receivers:
 
 exporters:
   splunk_hec:
-    token: {{ .SplunkHECToken }}
+    token: "{{ .SplunkHECToken }}"
     endpoint: {{ .SplunkHECEndpoint }}
     tls:
       insecure_skip_verify: true

--- a/tests/functional_tests/testdata/configs/multiple_topics_test.yaml.tmpl
+++ b/tests/functional_tests/testdata/configs/multiple_topics_test.yaml.tmpl
@@ -15,7 +15,7 @@ receivers:
 
 exporters:
   splunk_hec/{{ .KafkaTopicName1 }}:
-    token: {{ .SplunkHECToken }}
+    token: "{{ .SplunkHECToken }}"
     endpoint: {{ .SplunkHECEndpoint }}
     tls:
       insecure_skip_verify: true
@@ -31,7 +31,7 @@ exporters:
       batch:
         min_size: 1000
   splunk_hec/{{ .KafkaTopicName2 }}:
-    token: {{ .SplunkHECToken }}
+    token: "{{ .SplunkHECToken }}"
     endpoint: {{ .SplunkHECEndpoint }}
     tls:
       insecure_skip_verify: true

--- a/tests/functional_tests/testdata/configs/regex_test.yaml.tmpl
+++ b/tests/functional_tests/testdata/configs/regex_test.yaml.tmpl
@@ -9,7 +9,7 @@ receivers:
 
 exporters:
   splunk_hec:
-    token: {{ .SplunkHECToken }}
+    token: "{{ .SplunkHECToken }}"
     endpoint: {{ .SplunkHECEndpoint }}
     tls:
       insecure_skip_verify: true

--- a/tests/functional_tests/testdata/configs/timestamp_extraction_test.yaml.tmpl
+++ b/tests/functional_tests/testdata/configs/timestamp_extraction_test.yaml.tmpl
@@ -17,7 +17,7 @@ processors:
 
 exporters:
   splunk_hec:
-    token: {{ .SplunkHECToken }}
+    token: "{{ .SplunkHECToken }}"
     endpoint: {{ .SplunkHECEndpoint }}
     tls:
       insecure_skip_verify: true

--- a/tests/performance_tests/testdata/configs/basic_perf_test.yaml.tmpl
+++ b/tests/performance_tests/testdata/configs/basic_perf_test.yaml.tmpl
@@ -9,7 +9,7 @@ receivers:
 
 exporters:
   splunk_hec:
-    token: {{ .SplunkHECToken }}
+    token: "{{ .SplunkHECToken }}"
     endpoint: {{ .SplunkHECEndpoint }}
     tls:
       insecure_skip_verify: true


### PR DESCRIPTION
Fix for parsing the tokes including special character, so they are not seen as empty or malformed strings.